### PR TITLE
Replace argument type from array to variadic when setting annotation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Group::create('/swagger', [
             return $swaggerJson
                 // Uncomment cache for production environment
                 // ->withCache(3600)
-                ->withAnnotationPaths([
+                ->withAnnotationPaths(
                     '@src/Controller' // Path to API controllers
-                ]);
+                );
         })
         ->addMiddleware(FormatDataResponseAsJson::class),
 ]),

--- a/src/Middleware/SwaggerJson.php
+++ b/src/Middleware/SwaggerJson.php
@@ -45,7 +45,6 @@ final class SwaggerJson implements MiddlewareInterface
         return $this->responseFactory->createResponse($openApi);
     }
 
-
     /**
      * @param string ...$annotationPaths
      *

--- a/src/Middleware/SwaggerJson.php
+++ b/src/Middleware/SwaggerJson.php
@@ -45,12 +45,13 @@ final class SwaggerJson implements MiddlewareInterface
         return $this->responseFactory->createResponse($openApi);
     }
 
+
     /**
-     * @param string[] $annotationPaths
+     * @param string ...$annotationPaths
      *
      * @return self
      */
-    public function withAnnotationPaths(array $annotationPaths): self
+    public function withAnnotationPaths(string ...$annotationPaths): self
     {
         $new = clone $this;
         $new->annotationPaths = $annotationPaths;

--- a/tests/SwaggerJsonTest.php
+++ b/tests/SwaggerJsonTest.php
@@ -28,12 +28,12 @@ final class SwaggerJsonTest extends TestCase
     {
         $middleware = $this->createMiddleware();
 
-        $this->assertNotSame($middleware, $middleware->withAnnotationPaths([]));
+        $this->assertNotSame($middleware, $middleware->withAnnotationPaths());
         $this->assertNotSame($middleware, $middleware->withCache());
 
         /** @var DataResponse $response */
         $response = $middleware
-            ->withAnnotationPaths([__DIR__ . '/Support'])
+            ->withAnnotationPaths(__DIR__ . '/Support')
             ->process($this->createServerRequest(), $this->createRequestHandler());
 
         $this->assertSame(200, $response->getStatusCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -
