### PR TITLE
Fix #131: Fix implicitly nullable parameter in `SwaggerJson::withCache()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Enh #124: Add support for `yiisoft/html` version `^4.0` (@vjik)
 - Chg #129: Replace deprecated `ViewRenderer` with `WebViewRenderer` (@vjik)
 - Chg #130: Replace deprecated `DataResponseFactoryInterface` with new interface (@vjik)
+- Bug #131: Fix implicitly nullable parameter in `SwaggerJson::withCache()` (@vjik)
 
 ## 2.2.0 January 27, 2025
 

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "phpunit --display-deprecations",
         "psalm": "psalm",
         "cs-fix": "php-cs-fixer fix"
     }

--- a/src/Action/SwaggerJson.php
+++ b/src/Action/SwaggerJson.php
@@ -51,7 +51,7 @@ final class SwaggerJson implements RequestHandlerInterface
     /**
      * @param DateInterval|int|null $cacheTTL
      */
-    public function withCache(DateInterval|int $cacheTTL = null): self
+    public function withCache(DateInterval|int|null $cacheTTL = null): self
     {
         $new = clone $this;
         $new->enableCache = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
Fix #127 
